### PR TITLE
Fix search results with EstateCard

### DIFF
--- a/react-app/src/components/HomePage/EstateCard.js
+++ b/react-app/src/components/HomePage/EstateCard.js
@@ -4,7 +4,7 @@ import CrossfadeImage from "react-crossfade-image";
 
 import "./HomePage.css";
 
-const EstateCard = ({ estate }) => {
+const EstateCard = ({ estate, showType }) => {
   const [imageIndex, setImageIndex] = useState(0);
   const [carouseling, setCarouseling] = useState(false);
   const carouselLength = estate?.images?.length;
@@ -13,6 +13,7 @@ const EstateCard = ({ estate }) => {
   const interval = useRef();
 
   const address = `${estate?.city}, ${estate?.state}`;
+  const typeLine = `${estate?.type} in ${address}`;
 
   useEffect(() => {
     if (carouseling) {
@@ -39,7 +40,7 @@ const EstateCard = ({ estate }) => {
       </div>
       <div className="home-card-text">
         <div className="card-top-bar">
-          <div className="card-address">{address}</div>
+          <div className="card-address">{showType ? typeLine : address}</div>
           <div className="card-critique">
             <RatingDisplay rating={estate?.rating} places={2} />
           </div>

--- a/react-app/src/components/SearchResults/SearchResults.js
+++ b/react-app/src/components/SearchResults/SearchResults.js
@@ -45,6 +45,7 @@ const SearchResults = () => {
                 <EstateCard
                   className="search-results-card"
                   estate={estate}
+                  showType={true}
                 />
               );
             }

--- a/react-app/src/components/SearchResults/SearchResults.js
+++ b/react-app/src/components/SearchResults/SearchResults.js
@@ -5,6 +5,7 @@ import { useParams, useLocation, Link } from "react-router-dom";
 import loadAllResults from "../../store/search";
 import SearchMap from "./SearchMap/SearchMap";
 import "./SearchResults.css";
+import EstateCard from "../HomePage/EstateCard";
 
 const SearchResults = () => {
   const dispatch = useDispatch();
@@ -41,17 +42,10 @@ const SearchResults = () => {
               resultIds === estate.id.toString()
             ) {
               return (
-                <div className="search-results-card">
-                  <Link to={`/estates/${estate.id}`}>
-                    <img src={estate.images[0].url}></img>
-                  </Link>
-                  <Link to={`/estates/${estate.id}`}>
-                    <h3 style={{ color: "black" }}>
-                      {estate.type} in {estate.state}{" "}
-                    </h3>
-                  </Link>
-                  <p>${estate.nightly_rate} night</p>
-                </div>
+                <EstateCard
+                  className="search-results-card"
+                  estate={estate}
+                />
               );
             }
           })}


### PR DESCRIPTION
technically @pmelhus fixed this in a PR that I was ignoring because I was sleepy, but this is a bit more DRY fix since it uses the estate card we use on the home page.  Adds an optional type prop to the estate card to show the estate type.