### PR TITLE
fix margin on estate card with no images

### DIFF
--- a/react-app/src/components/HomePage/HomePage.css
+++ b/react-app/src/components/HomePage/HomePage.css
@@ -63,6 +63,10 @@
     width:277px;
 }
 
+.home-card-img p{
+    margin:0;
+}
+
 .footer-backer{
     position: fixed;
     bottom:0;


### PR DESCRIPTION
- fixed margin issue on estate cards with no images so they are all even in search and in the home page